### PR TITLE
Template consolidation #68007

### DIFF
--- a/lib/framework/public/css/style.css
+++ b/lib/framework/public/css/style.css
@@ -100,6 +100,9 @@
 
 /* stupid style fixes */
 .eea-icon:before { margin: auto; }
+#content .jstree-container-ul {
+    margin-left: 0;
+}
 .jstree-default a.jstree-anchor { white-space: nowrap; }
 
 /* tile clearing */
@@ -178,7 +181,7 @@
 /* filter group container */
 .facetview_tree {
     margin: -1px;
-    border-color: #DDD!important;
+    border-color: #DDD !important;
     box-shadow: inset 0 2px 3px -1px rgba(0,0,0,.1);
 }
 
@@ -231,6 +234,9 @@
     vertical-align: -3px;
 }
 
+#content .facetview_geocontainer a.geo-facet-type:link {
+    color: rgb(45, 116, 156) !important;
+}
 
 /* current filters */
 .filters-header,
@@ -349,16 +355,22 @@ div#footer-wrapper {
 }
 
 .download_data div {
-    float:right
+    float:right;
 }
 
 .eea_download_btn,
 .eea_download_btn:hover,
 .eea_download_btn:visited{
-    border:1px solid #ddd;
+    border:1px solid #ddd !important;
     padding:7px !important;
     color:black !important;
 }
+
+/* bootstrap fixes */
+.table-bordered {
+    border-collapse: separate !important;
+}
+
 
 .row-fluid .span3 {
     float:right;

--- a/lib/framework/public/css/style.css
+++ b/lib/framework/public/css/style.css
@@ -103,6 +103,10 @@
 #content .jstree-container-ul {
     margin-left: 0;
 }
+.jstree-default .jstree-container-ul .jstree-node {
+    margin-left: 0;
+    margin-right: 0;
+}
 .jstree-default a.jstree-anchor { white-space: nowrap; }
 
 /* tile clearing */

--- a/lib/framework/public/css/style.css
+++ b/lib/framework/public/css/style.css
@@ -149,6 +149,7 @@
 
 .pagination li {
     float: none !important;
+    display: inline-block !important;
 }
 
 .pagination ul {

--- a/lib/framework/public/css/style.css
+++ b/lib/framework/public/css/style.css
@@ -30,10 +30,6 @@
     border-bottom-color: #fff;
 }
 
-#facetview_filters > h2 {
-    font-size: 120%;
-}
-
 .facetview_selection {
     width: 100%;
     float:left;
@@ -160,13 +156,17 @@
 }
 
 /* filter group */
-.eea-accordion-panels .eea-accordion-panel > h2 {
+#content .eea-accordion-panels .eea-accordion-panel > h2 {
     background-color: #fff;
+    color: #00446A;
     border-bottom: none;
     border-left-style: none;
     border-right-style: none;
     font-size: 100%;
+    margin: 0;
+    line-height: 3em;
 }
+
 .eea-accordion-panel .facetview_open .eea-icon:before {
     content: "\f078";
 }
@@ -308,6 +308,11 @@ div.content h1 {
   color: #2d749c;
   font-weight: bold;
   line-height: 1.3;
+}
+
+#facetview_filters h2 {
+    font-size: 120%;
+    color: #00446A;
 }
 
 table#facetview_results {

--- a/lib/framework/public/facetview/jquery.facetview.js
+++ b/lib/framework/public/facetview/jquery.facetview.js
@@ -3159,7 +3159,7 @@ function sortNumber(a,b){
         if (options.facets.length > 0 || options.static_filters.length > 0) {
             thefacetview = [
                 thefacetview,
-                '<div class="span3" style="margin-left:0px">',
+                '<div class="span3 right-column-area" style="margin-left:0px">',
                 '<div id="facetview_filters"><h2>Filter your results</h2>',
                 '</div><div class="current-filters">',
                 '<div class="filters-header" style="display:none">',

--- a/lib/framework/views/details.jade
+++ b/lib/framework/views/details.jade
@@ -28,3 +28,15 @@ mixin detail_tables(section, data, href_base, show_missing)
                     col(style="width: 75%")
                 each field in section.fields
                     +tr_th_td(data[field.name], href_base, field.name, show_missing)
+
+mixin portal_breadcrumbs(parent_title, current_title)
+        div(id="portal-breadcrumbs")
+            span(id="breadcrumbs-you-are-here") You are here:
+            span(id="breadcrumbs-home")
+                a(href="http://www.eea.europa.eu/") Home
+                span(class="breadcrumbSeparator")  /
+            span(id="breadcrumbs-1")
+                a(href="./") parent_title
+                span(class="breadcrumbSeparator")  /
+            span(id="breadcrumbs-2")
+                span(class="breadcrumbs-current")= current_title

--- a/lib/framework/views/details.jade
+++ b/lib/framework/views/details.jade
@@ -1,3 +1,5 @@
+include ./mixins.jade
+
 mixin tr_th_td(item, href_base, field_name, show_missing)
     if(item && item.value)
         tr(class=field_name)
@@ -29,14 +31,3 @@ mixin detail_tables(section, data, href_base, show_missing)
                 each field in section.fields
                     +tr_th_td(data[field.name], href_base, field.name, show_missing)
 
-mixin portal_breadcrumbs(parent_title, current_title)
-        div(id="portal-breadcrumbs")
-            span(id="breadcrumbs-you-are-here") You are here:
-            span(id="breadcrumbs-home")
-                a(href="http://www.eea.europa.eu/") Home
-                span(class="breadcrumbSeparator")  /
-            span(id="breadcrumbs-1")
-                a(href="./")= parent_title
-                span(class="breadcrumbSeparator")  /
-            span(id="breadcrumbs-2")
-                span(class="breadcrumbs-current")= current_title

--- a/lib/framework/views/details.jade
+++ b/lib/framework/views/details.jade
@@ -36,7 +36,7 @@ mixin portal_breadcrumbs(parent_title, current_title)
                 a(href="http://www.eea.europa.eu/") Home
                 span(class="breadcrumbSeparator")  /
             span(id="breadcrumbs-1")
-                a(href="./") parent_title
+                a(href="./")= parent_title
                 span(class="breadcrumbSeparator")  /
             span(id="breadcrumbs-2")
                 span(class="breadcrumbs-current")= current_title

--- a/lib/framework/views/layout.jade
+++ b/lib/framework/views/layout.jade
@@ -34,12 +34,14 @@ html
 
     body
         != templateRender(headerFile)
-        div(class="container")
-            div(class="content" id="content")
-                block content
-                div(class="documentActions")
-                    h5(class="hiddenStructure") Document Actions
-            div(id="right-column", class="right-column-area")
-                div(class="visualPadding")
-            div(class="visualClear")
+        div(id="portal-columns")
+            div(class="container")
+                div(class="content" id="content")
+                    block content
+                    div(class="documentActions")
+                        h5(class="hiddenStructure") Document Actions
+                div(id="right-column", class="right-column-area")
+                    div(class="visualPadding")
+                div(class="visualClear")
+
     != templateRender(footerFile)

--- a/lib/framework/views/layout.jade
+++ b/lib/framework/views/layout.jade
@@ -1,3 +1,4 @@
+include ./mixins.jade
 doctype html
 html
     head

--- a/lib/framework/views/mixins.jade
+++ b/lib/framework/views/mixins.jade
@@ -1,0 +1,11 @@
+mixin portal_breadcrumbs(parent_title, current_title)
+        div(id="portal-breadcrumbs")
+            span(id="breadcrumbs-you-are-here") You are here:
+            span(id="breadcrumbs-home")
+                a(href="http://www.eea.europa.eu/") Home
+                span(class="breadcrumbSeparator")  /
+            span(id="breadcrumbs-1")
+                a(href="./")= parent_title
+                span(class="breadcrumbSeparator")  /
+            span(id="breadcrumbs-2")
+                span(class="breadcrumbs-current")= current_title

--- a/lib/framework/views/mixins.jade
+++ b/lib/framework/views/mixins.jade
@@ -5,7 +5,11 @@ mixin portal_breadcrumbs(parent_title, current_title)
                 a(href="http://www.eea.europa.eu/") Home
                 span(class="breadcrumbSeparator")  /
             span(id="breadcrumbs-1")
-                a(href="./")= parent_title
-                span(class="breadcrumbSeparator")  /
-            span(id="breadcrumbs-2")
-                span(class="breadcrumbs-current")= current_title
+                if current_title
+                    a(href="./")= parent_title
+                    span(class="breadcrumbSeparator")  /
+                else
+                    span(class="breadcrumbs-current")= parent_title
+            if current_title
+                span(id="breadcrumbs-2")
+                    span(class="breadcrumbs-current")= current_title

--- a/lib/framework/views/mixins.jade
+++ b/lib/framework/views/mixins.jade
@@ -19,7 +19,7 @@ mixin visualization_info(href, title)
         h3 Data sources
         a(href=href)= title
         span  provided by
-        a(href="http://www.eea.europa.eu") European Environment Agency (EEA)
+        a(href="http://www.eea.europa.eu")  European Environment Agency (EEA)
 
 mixin app_error(title, app_id)
     div(class = "portalMessage errorMessage")

--- a/lib/framework/views/mixins.jade
+++ b/lib/framework/views/mixins.jade
@@ -24,5 +24,5 @@ mixin visualization_info(href, title)
 mixin app_error(title, app_id)
     div(class = "portalMessage errorMessage")
         span= "PAM with ID: "
-        b= pamid
+        b= app_id
         span= " does not exist"

--- a/lib/framework/views/mixins.jade
+++ b/lib/framework/views/mixins.jade
@@ -20,3 +20,9 @@ mixin visualization_info(href, title)
         a(href=href)= title
         span  provided by
         a(href="http://www.eea.europa.eu") European Environment Agency (EEA)
+
+mixin app_error(title, app_id)
+    div(class = "portalMessage errorMessage")
+        span= "PAM with ID: "
+        b= pamid
+        span= " does not exist"

--- a/lib/framework/views/mixins.jade
+++ b/lib/framework/views/mixins.jade
@@ -13,3 +13,10 @@ mixin portal_breadcrumbs(parent_title, current_title)
             if current_title
                 span(id="breadcrumbs-2")
                     span(class="breadcrumbs-current")= current_title
+
+mixin visualization_info(href, title)
+    div(class="visualization-info")
+        h3 Data sources
+        a(href=href)= title
+        span  provided by
+        a(href="http://www.eea.europa.eu") European Environment Agency (EEA)


### PR DESCRIPTION
Added styles and markup needed for the html5 markup found at http://www.eea.europa.eu/code/templates/eea-main-template-v2.

Along the way I took what was common from eea.docker.pam and
eea.docker.aide as can be seen in the attached commits.
